### PR TITLE
[OP-2197] Update Go to fix GO-2023-2185

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-FROM docker.io/library/golang:1.21-alpine AS build
+FROM docker.io/library/golang:1.21.4-alpine AS build
 
 WORKDIR /opt/ri-forward-webhook
 COPY go.mod go.sum .

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/RiskIdent/ri-forward-webhook
 
-go 1.21.3
+go 1.21.4
 
 require (
 	github.com/gin-gonic/gin v1.9.1


### PR DESCRIPTION
OP-2197

Fixes: https://pkg.go.dev/vuln/GO-2023-2185
