### PR TITLE
Update Go to fix GO-2023-2182 and GO-2023-2185

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/RiskIdent/ri-forward-webhook
 
-go 1.21.4
+go 1.21.5
 
 require (
 	github.com/gin-gonic/gin v1.9.1


### PR DESCRIPTION
Govulncheck output:

```
Vulnerability #1: GO-2023-2382
    Denial of service via chunk extensions in net/http
  More info: https://pkg.go.dev/vuln/GO-2023-2382
  Standard library
    Found in: net/http/internal@go1.21.4
    Fixed in: net/http/internal@go1.21.5
    Example traces found:
Error:       #1: server.go:58:18: ri.Server.Serve calls gin.Engine.Run, which eventually calls internal.chunkedReader.Read

Vulnerability #2: GO-2023-2185
    Insecure parsing of Windows paths with a \??\ prefix in path/filepath
  More info: https://pkg.go.dev/vuln/GO-2023-2185
  Standard library
    Found in: path/filepath@go1.21.4
    Fixed in: path/filepath@go1.21.5
    Platforms: windows
    Example traces found:
Error:       #1: endpoint.go:26:2: ri.init calls http.init, which eventually calls filepath.Join
Error:       #2: endpoint.go:26:2: ri.init calls http.init, which eventually calls filepath.Join
```

Source: https://github.com/RiskIdent/ri-forward-webhook/actions/runs/7164520125/job/19504742561
