### PR TITLE
Update to Go 1.22.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-FROM docker.io/library/golang:1.22.2-alpine AS build
+FROM docker.io/library/golang:1.22.3-alpine AS build
 
 WORKDIR /opt/ri-forward-webhook
 COPY go.mod go.sum .

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/RiskIdent/ri-forward-webhook
 
-go 1.22.2
+go 1.22.3
 
 require (
 	github.com/gin-gonic/gin v1.9.1


### PR DESCRIPTION
Resolves vulnerability: https://pkg.go.dev/vuln/GO-2024-2824
