### PR TITLE
Updated to Go 1.22.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/RiskIdent/ri-forward-webhook
 
-go 1.22.4
+go 1.22.5
 
 require (
 	github.com/gin-gonic/gin v1.10.0


### PR DESCRIPTION
Resolves vulnerability reported by govulncheck:

```
=== Symbol Results ===

Vulnerability #1: GO-2024-2963
    Denial of service due to improper 100-continue handling in net/http
  More info: https://pkg.go.dev/vuln/GO-2024-2963
  Standard library
    Found in: net/http@go1.22.4
    Fixed in: net/http@go1.22.5
    Example traces found:
       #1: endpoint.go:77:26: ri.endpointHandler.doForwardedReq calls http.Client.Do
```
